### PR TITLE
Fix includeHTML bug

### DIFF
--- a/assets/js/detalles.js
+++ b/assets/js/detalles.js
@@ -2,10 +2,10 @@
 
 /*Fucncion de las peticiones asincrona*/
 function includeHTML(elmnt) {
-	var getUrl = window.location;
-	var baseUrl = getUrl.protocol + "//" + getUrl.host + "/" + getUrl.pathname.split('/')[1];
-	var elmnt, file;
-	file = elmnt.getAttribute("includedHtml");
+       var getUrl = window.location;
+       var baseUrl = getUrl.protocol + "//" + getUrl.host + "/" + getUrl.pathname.split('/')[1];
+       var file;
+       file = elmnt.getAttribute("includedHtml");
 	if (file) {
 		return $.ajax(baseUrl+file);
 	}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,10 +2,10 @@
 
 /*Funcion de las peticiones asincrona*/
 function includeHTML(elmnt) {
-	var getUrl = window.location;
-	var baseUrl = getUrl.protocol + "//" + getUrl.host + "/" + getUrl.pathname.split('/')[1];
-	var elmnt, file;
-	file = elmnt.getAttribute("includedHtml");
+       var getUrl = window.location;
+       var baseUrl = getUrl.protocol + "//" + getUrl.host + "/" + getUrl.pathname.split('/')[1];
+       var file;
+       file = elmnt.getAttribute("includedHtml");
 	if (file) {
 		return $.ajax({
 			url: baseUrl+file,


### PR DESCRIPTION
## Summary
- fix misuse of includeHTML parameter in main.js and detalles.js

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f9b421e8883218fd19a6dda3240aa